### PR TITLE
Compatibility with Python 3.10

### DIFF
--- a/dendropy/utility/container.py
+++ b/dendropy/utility/container.py
@@ -21,6 +21,7 @@ Various data structures.
 """
 
 import collections
+from collections.abc import MutableMapping
 import copy
 import sys
 import csv
@@ -353,7 +354,7 @@ class NormalizedBitmaskDict(collections.OrderedDict):
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class CaseInsensitiveDict(collections.MutableMapping):
+class CaseInsensitiveDict(collections.abc.MutableMapping):
     """
     A case-insensitive ``dict``-like object.
 


### PR DESCRIPTION
Usage of collections.abc to provide MutableMapping to work with Python 3.10. It fixes https://github.com/uym2/TreeShrink/issues/33 (tested for installation using `python3.10 setup.py install --user`).